### PR TITLE
Add images to list items, continue reading links (optional)

### DIFF
--- a/packages/common/components/blocks/ad/promotion-advertisement.marko
+++ b/packages/common/components/blocks/ad/promotion-advertisement.marko
@@ -31,13 +31,13 @@ $ const imgLinkStyles = {
             <table role="presentation" width="100%" border="0" cellspacing="0" cellpadding="0">
               <common-table-spacer-element height="12" />
               <tr>
-                <td align="right" valign="top" width="330" class="split_cont1">
+                <td align="right" valign="top" width="270" class="split_cont1">
                   <marko-core-obj-value|{ value: image }| obj=content field="primaryImage" as="object">
                     <marko-newsletter-imgix
                       src=image.src
                       alt=image.alt
-                      options={ w: 660, h: 440, fit: "crop", auto: "format,compress" }
-                      attrs={ border: 0, width: 330, style: imgStyles }
+                      options={ w: 540, h: 360, fit: "crop", auto: "format,compress" }
+                      attrs={ border: 0, width: 270, style: imgStyles }
                     >
                       <@link href=url target="_blank" attrs={ style: imgLinkStyles } />
                     </marko-newsletter-imgix>
@@ -61,11 +61,11 @@ $ const imgLinkStyles = {
                     </tr>
                     <common-table-spacer-element height="12" />
                     <tr>
-                      <td align="left" valign="top" style="font-size: 16px;line-height: 22px;color: #202022;padding:0 24px 0 0;">${content.teaser}</td>
+                      <td align="left" valign="top" style="font-size: 17px;line-height: 22px;color: #202022;padding:0 24px 0 0;">${content.teaser}</td>
                     </tr>
                     <common-table-spacer-element height="9" />
                     <tr>
-                      <td align="left" valign="top" style="font-size: 16px;line-height: 22px;color: #3475b6;font-weight: 400;">
+                      <td align="left" valign="top" style="font-size: 17px;line-height: 22px;color: #3475b6;font-weight: 400;">
                         <a href=url target="_blank" style="text-decoration: none;color: #3475b6;padding:0 24px 0 0;">${content.name}</a>
                       </td>
                     </tr>

--- a/packages/common/components/blocks/content/list-item.marko
+++ b/packages/common/components/blocks/content/list-item.marko
@@ -53,7 +53,8 @@ $ const sponsoredTagStyle = {
       </else-if>
 
       <common-table-spacer-element height="6" />
-      <if(withImage && content.primaryImage)>
+
+      <if(withImage && imagePosition === 'top' && content.primaryImage)>
         <common-table-spacer-element height="6" />
         <tr>
           <td align="center" valign="top">
@@ -72,15 +73,104 @@ $ const sponsoredTagStyle = {
         </tr>
         <common-table-spacer-element height="10" />
       </if>
-      <tr>
-        <td align="left" valign="top">
-          <a style="font-size: 24px;line-height: 28px;color: #202022;font-weight: 700;text-decoration: none;" href=content.siteContext.url>${content.name}</a>
-        </td>
-      </tr>
-      <common-table-spacer-element height="5" />
-      <tr>
-        <td align="left" valign="middle" style="font-size: 17px;line-height: 23px;color: #202022;font-weight: 400;">${content.teaser}</td>
-      </tr>
+
+      <if(withImage && imagePosition === 'right' && content.primaryImage)>
+        <tr>
+          <td align="center" valign="top" dir="ltr">
+            <table role="presentation" width="100%" border="0" cellspacing="0" cellpadding="0">
+              <tr>
+                <td align="left" valign="top">
+                  <table role="presentation" width="100%" border="0" cellpadding="0" cellspacing="0" class="pad" style="padding: 0 30px 0px 0;">
+                    <tr>
+                      <td align="left" valign="top">
+                        <a style="font-size: 24px;line-height: 28px;color: #202022;font-weight: 700;text-decoration: none;" class="font1" href=content.siteContext.url>
+                          ${content.name}
+                        </a>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td>
+                        <table role="presentation" width="100%" border="0" cellspacing="0" cellpadding="0" class="hide_on_mobile">
+                          <common-table-spacer-element height="5" />
+                          <tr>
+                            <td align="left" valign="top" style="font-size: 17px;line-height: 23px;color: #202022;font-weight: 400;">
+                              ${content.teaser}
+                            </td>
+                          </tr>
+                          <if(continueReading)>
+                            <common-table-spacer-element height="9" />
+                            <tr>
+                              <td align="left" valign="top" style="font-size: 17px;line-height: 23px;color:#3475b6;font-weight: 400;">
+                                Continue Reading
+                              </td>
+                            </tr>
+                          </if>
+                        </table>
+                      </td>
+                    </tr>
+                  </table>
+                </td>
+                <td align="right" valign="top" width="200" class="wdt">
+                  <marko-core-obj-value|{ value: image }| obj=content field="primaryImage" as="object">
+                    <marko-newsletter-imgix
+                      src=image.src
+                      alt=image.alt
+                      options={ w: 400, h: 266, fit: "crop", auto: "format,compress" }
+                      class="img_resize2"
+                      attrs={ border: 0, width: 200, height: 133, style: imgStyles }
+                    >
+                      <@link href=content.siteContext.url target="_blank" attrs={ style: imgLinkStyles } />
+                    </marko-newsletter-imgix>
+                  </marko-core-obj-value>
+                </td>
+              </tr>
+            </table>
+          </td>
+        </tr>
+        <tr>
+          <td align="left" valign="top" class="show_on_mobile" style="display: none;mso-hide: all;">
+            <table role="presentation" width="100%" border="0" cellspacing="0" cellpadding="0" style="mso-hide: all;">
+              <common-table-spacer-element height="10" />
+              <tr>
+                <td align="left" valign="top" style="font-size: 17px;line-height: 23px;color: #202022;font-weight: 400;">
+                  ${content.teaser}
+                </td>
+              </tr>
+              <if(continueReading)>
+                <common-table-spacer-element height="9" />
+                <tr>
+                  <td align="left" valign="top" style="font-size: 17px;line-height: 23px;color: #3475b6;font-weight: 400;">
+                    Continue Reading
+                  </td>
+                </tr>
+              </if>
+            </table>
+          </td>
+        </tr>
+      </if>
+      <else>
+        <tr>
+          <td align="left" valign="top">
+            <a style="font-size: 24px;line-height: 28px;color: #202022;font-weight: 700;text-decoration: none;" href=content.siteContext.url>
+              ${content.name}
+            </a>
+          </td>
+        </tr>
+        <common-table-spacer-element height="5" />
+        <tr>
+          <td align="left" valign="middle" style="font-size: 17px;line-height: 23px;color: #202022;font-weight: 400;">
+            ${content.teaser}
+          </td>
+        </tr>
+        <if(continueReading)>
+          <common-table-spacer-element height="9" />
+          <tr>
+            <td align="left" valign="top" style="font-size: 17px;line-height: 23px;color: #3475b6;font-weight: 400;">
+              Continue Reading
+            </td>
+          </tr>
+        </if>
+      </else>
       <common-table-spacer-element height="32" />
     </table>
   </td>

--- a/packages/common/components/blocks/content/list-item.marko
+++ b/packages/common/components/blocks/content/list-item.marko
@@ -4,7 +4,9 @@ import defaultValue from "@parameter1/base-cms-marko-core/utils/default-value";
 $ const { content } = input;
 
 $ const withImage = defaultValue(input.withImage, false);
+$ const imagePosition = defaultValue(input.imagePosition, 'right');
 $ const withSection = defaultValue(input.withSection, true);
+$ const continueReading = defaultValue(input.continueReading, false);
 
 $ const imgStyles = {
   "border": 0,

--- a/packages/common/components/blocks/content/list.marko
+++ b/packages/common/components/blocks/content/list.marko
@@ -25,7 +25,13 @@ $ const queryParams = {
       <common-list-header-element title=sectionName />
     </if>
     <for|content| of=nodes>
-      <common-content-list-item-block content=content with-section=withSection with-image=withImage />
+      <common-content-list-item-block
+        content=content
+        with-section=withSection
+        with-image=withImage
+        image-position=imagePosition
+        continue-reading=continueReading
+      />
     </for>
   </if>
 </marko-web-query>

--- a/packages/common/components/blocks/content/list.marko
+++ b/packages/common/components/blocks/content/list.marko
@@ -5,8 +5,10 @@ import queryFragment from "@randall-reilly/package-common/graphql/fragments/cont
 $ const { sectionName, date, newsletter } = input;
 
 $ const withImage = defaultValue(input.withImage, false);
+$ const imagePosition = defaultValue(input.imagePosition, 'right');
 $ const withHeader = defaultValue(input.withHeader, false);
 $ const withSection = defaultValue(input.withSection, true);
+$ const continueReading = defaultValue(input.continueReading, false);
 
 $ const queryParams = {
   date: date.valueOf(),

--- a/packages/common/components/blocks/head.marko
+++ b/packages/common/components/blocks/head.marko
@@ -27,15 +27,33 @@
     @media screen and (max-width:599px) {
   .split_cont1 {width: 100% !important;display: inline-block !important;text-align: center !important;padding: 0 0px 10px 0px !important;}
     }
-    @media screen and (max-width: 479px) {
-  .mobile{display: block !important;}
-  .mobile1{display: none!important;}
-  .wdth{text-align: left !important;padding: 0 29px 0 0 !important;}
-  .font1{font-size: 25px !important;}
-  .img_resize2{width: 100% !important; height: auto !important;}
+  @media screen and (max-width: 479px) {
+    .wdt{width: 180px !important;}
+    .mobile{display: block !important;}
+    .mobile1{display: none!important;}
+    .wdth{text-align: left !important;padding: 0 29px 0 0 !important;}
+    .font1{font-size: 21px !important;line-height: 24px !important}
+    .img_resize2{width: 100% !important; height: auto !important;}
     .height-resize{height: 15px !important;}
     .split{width:100% !important;display: inline-block !important;padding: 0 0 20px 0 !important;}
     .wid_5{width: 100% !important;}
     .split1{display:none !important;}
+    .split_cont1{width: 100% !important;display: inline-block !important;text-align: center !important;padding: 0 0px 10px 0px !important;}
+    *[class~=show_on_mobile] {
+      display: block !important;
+      width: auto !important;
+      max-height: inherit !important;
+      overflow: visible !important;
+      float: none !important;
     }
+    *[class~=hide_on_mobile] {
+      display: none !important;
+    }
+    .pad{padding: 0 5px 0 0 !important;}
+  }
+  @media screen and (max-width: 350px) {
+    .wdt{width: 150px !important;}
+    .font1{font-size: 15px !important;line-height: 18px !important;}
+    .font2{font-size: 14px !important;}
+  }
 </style>

--- a/packages/common/components/layouts/daily.marko
+++ b/packages/common/components/layouts/daily.marko
@@ -48,6 +48,7 @@ $ const continueReading = get(req, 'query.continue-reading') || false;
           section-name="Top Story"
           newsletter=newsletter
           with-image=true
+          image-position='top'
           limit=1
         />
 
@@ -66,7 +67,9 @@ $ const continueReading = get(req, 'query.continue-reading') || false;
           date=date
           section-name="Main"
           newsletter=newsletter
-          with-image=false
+          with-image=withImage
+          image-position='right'
+          continue-reading=continueReading
           limit=2
           skip=0
         />
@@ -86,7 +89,9 @@ $ const continueReading = get(req, 'query.continue-reading') || false;
           date=date
           section-name="Main"
           newsletter=newsletter
-          with-image=false
+          with-image=withImage
+          image-position='right'
+          continue-reading=continueReading
           limit=2
           skip=2
         />
@@ -106,7 +111,9 @@ $ const continueReading = get(req, 'query.continue-reading') || false;
           date=date
           section-name="Main"
           newsletter=newsletter
-          with-image=false
+          with-image=withImage
+          image-position='right'
+          continue-reading=continueReading
           limit=1
           skip=4
         />
@@ -133,7 +140,9 @@ $ const continueReading = get(req, 'query.continue-reading') || false;
           date=date
           section-name="Main"
           newsletter=newsletter
-          with-image=false
+          with-image=withImage
+          image-position='right'
+          continue-reading=continueReading
           limit=1
           skip=5
         />
@@ -154,6 +163,8 @@ $ const continueReading = get(req, 'query.continue-reading') || false;
           section-name="Main"
           newsletter=newsletter
           with-image=true
+          image-position='top'
+          continue-reading=continueReading
           limit=1
           skip=6
         />

--- a/packages/common/components/layouts/daily.marko
+++ b/packages/common/components/layouts/daily.marko
@@ -2,7 +2,7 @@ import queryFragment from "@randall-reilly/package-common/graphql/fragments/cont
 import rotateArray from "@randall-reilly/package-common/utils/rotate-array";
 import { get } from "@parameter1/base-cms-object-path";
 
-$ const { website, config } = out.global;
+$ const { website, config, req } = out.global;
 $ const { newsletter, date } = input.data;
 
 $ const emailX = config.get("emailX");
@@ -10,6 +10,9 @@ $ const nativeX = config.getAsObject("nativeX");
 $ const dayOfWeek = new Date(date).getDay() || 7;
 $ const adUnits = ["rotation-a", "rotation-e", "rotation-d", "rotation-c", "rotation-b"];
 $ const adSlots = rotateArray(adUnits, dayOfWeek - 1);
+
+$ const withImage = get(req, 'query.with-image') || false;
+$ const continueReading = get(req, 'query.continue-reading') || false;
 
 <marko-newsletter-root
   title=newsletter.name


### PR DESCRIPTION
This new feature is being used for A/B testing.  At present, URL parameters will be used to implement via manual deployments.

Example path to enable both options:
/templates/ccj-daily?date=1617858000000&with-image=true&continue-reading=true

<img width="1264" alt="Screen Shot 2021-04-10 at 2 48 12 PM" src="https://user-images.githubusercontent.com/2855198/114282829-e60f1d00-9a0b-11eb-8260-191e624e3c7f.png">
<img width="777" alt="Screen Shot 2021-04-10 at 2 48 01 PM" src="https://user-images.githubusercontent.com/2855198/114282833-e7d8e080-9a0b-11eb-9307-0ed931edbfec.png">
