### PR TITLE
Add ‘Partner Insights’ Native Ad placement to daily-2 layout

### DIFF
--- a/packages/common/components/layouts/daily-2.marko
+++ b/packages/common/components/layouts/daily-2.marko
@@ -95,6 +95,15 @@ $ const urlParams = (utmTerm) ? { "utm_term" : utmTerm } : false;
           skip=1
         />
 
+        <!-- Partner Insights / Promotion block -->
+        <common-ad-wrapper-block
+          date=date
+          section-name="Partner Insights"
+          newsletter=newsletter
+          promotion-component="native-block"
+          placement-id=get(nativeX, `placements.${newsletter.alias}.partner-insights`)
+        />
+
         <!-- Advertisement / Promotion block -->
         <common-ad-wrapper-block
           date=date


### PR DESCRIPTION
Dev:
<img width="773" alt="Screen Shot 2023-02-09 at 11 25 57 AM" src="https://user-images.githubusercontent.com/64623209/217891643-f01849e4-ba60-4326-98d1-f4b7031371a4.png">
Prod:
<img width="851" alt="Screen Shot 2023-02-09 at 11 26 21 AM" src="https://user-images.githubusercontent.com/64623209/217891647-c56d83ad-36f7-4ccc-861a-fa6842f3ea88.png">
