### PR TITLE
Update logos in all brands except TN

### DIFF
--- a/tenants/all/config/brands.js
+++ b/tenants/all/config/brands.js
@@ -1,7 +1,7 @@
 module.exports = {
   ccj: {
     brandName: 'Commercial Carrier Journal',
-    logoSrc: '/files/base/randallreilly/all/image/static/ccj/ccj-white-logo.png',
+    logoSrc: '/files/base/randallreilly/all/image/static/ccj/ByFusableMediaBrandsLogos_CCJ-REV.svg',
     subscribeLink: 'https://randallreilly.dragonforms.com/loading.do?omedasite=ccj_subscriptions',
     unsubscribeLink: 'https://sample.dragonforms.com/loading.do?omedasite=CCJ_prefcntr&r=@{encrypted_customer_id}@',
     contactLinks: [
@@ -20,7 +20,7 @@ module.exports = {
   },
   eqw: {
     brandName: 'Equipment World',
-    logoSrc: '/files/base/randallreilly/all/image/static/eqw/eqw-white-logo.png',
+    logoSrc: '/files/base/randallreilly/all/image/static/eqw/ByFusableMediaBrandsLogos_EquipmentWorld-REV.svg',
     subscribeLink: 'https://randallreilly.dragonforms.com/loading.do?omedasite=eqw_subscriptions',
     contactLinks: [
       { href: 'https://www.equipmentworld.com/page/advertise', label: 'Advertising' },
@@ -38,7 +38,7 @@ module.exports = {
   },
   ovd: {
     brandName: 'Overdrive',
-    logoSrc: '/files/base/randallreilly/all/image/static/ovd/ovd-white-logo.png',
+    logoSrc: '/files/base/randallreilly/all/image/static/ovd/ByFusableMediaBrandsLogos_OVD-REV.svg',
     subscribeLink: 'https://randallreilly.dragonforms.com/loading.do?omedasite=ov_subscriptions',
     tagline: 'The Voice of the American Trucker',
     contactLinks: [
@@ -58,7 +58,7 @@ module.exports = {
   },
   tlc: {
     brandName: 'Total Landscape Care',
-    logoSrc: '/files/base/randallreilly/all/image/static/tlc/tlc-white-logo.png',
+    logoSrc: '/files/base/randallreilly/all/image/static/tlc/ByFusableMediaBrandsLogos_TLC-REV.svg',
     subscribeLink: 'https://randallreilly.dragonforms.com/loading.do?omedasite=tlc_subscriptions',
     contactLinks: [
       { href: 'https://www.totallandscapecare.com/page/advertise', label: 'Advertising' },
@@ -94,7 +94,7 @@ module.exports = {
   },
   tps: {
     brandName: 'Trucks, Parts, Service',
-    logoSrc: '/files/base/randallreilly/all/image/static/tps/tps-white-logo.png',
+    logoSrc: '/files/base/randallreilly/all/image/static/tps/ByFusableMediaBrandsLogos_TPS-REV.svg',
     subscribeLink: 'https://randallreilly.dragonforms.com/loading.do?omedasite=tps_subscriptions',
     contactLinks: [
       { href: 'https://www.truckpartsandservice.com/page/advertise', label: 'Advertising' },
@@ -112,7 +112,7 @@ module.exports = {
   },
   hwt: {
     brandName: 'Hard Working Trucks',
-    logoSrc: '/files/base/randallreilly/all/image/static/hwt/hwt-white-logo.png',
+    logoSrc: '/files/base/randallreilly/all/image/static/hwt/ByFusableMediaBrandsLogos_HWT-REV.svg',
     subscribeLink: 'https://randallreilly.dragonforms.com/loading.do?omedasite=hwt_subscriptions',
     contactLinks: [
       { href: 'https://www.hardworkingtrucks.com/page/advertise', label: 'Advertising' },
@@ -130,7 +130,7 @@ module.exports = {
   },
   ct: {
     brandName: 'Clean Trucking',
-    logoSrc: '/files/base/randallreilly/all/image/static/ct/ct-logo-white.png',
+    logoSrc: '/files/base/randallreilly/all/image/static/ct/ByFusableMediaBrandsLogos_CleanTrucking-REV.svg',
     subscribeLink: 'https://randallreilly.dragonforms.com/loading.do?omedasite=CT_nlsignup',
     contactLinks: [
       { href: 'https://www.cleantrucking.com/page/advertise', label: 'Advertising' },


### PR DESCRIPTION
<img width="549" alt="Screen Shot 2024-01-16 at 8 29 59 AM" src="https://github.com/parameter1/randall-reilly-newsletters/assets/64623209/5be5d57f-99c6-4352-b6b1-58f7937e9842">
<img width="549" alt="Screen Shot 2024-01-16 at 8 33 00 AM" src="https://github.com/parameter1/randall-reilly-newsletters/assets/64623209/8109c33b-9851-4554-9768-636b1df83a01">
<img width="554" alt="Screen Shot 2024-01-16 at 8 34 37 AM" src="https://github.com/parameter1/randall-reilly-newsletters/assets/64623209/a5761aa3-8338-46b8-9250-189bdd00f6db">
<img width="588" alt="Screen Shot 2024-01-16 at 8 36 13 AM" src="https://github.com/parameter1/randall-reilly-newsletters/assets/64623209/62c5f3db-b58c-4827-9dfb-332b3e10af83">
<img width="545" alt="Screen Shot 2024-01-16 at 8 38 10 AM" src="https://github.com/parameter1/randall-reilly-newsletters/assets/64623209/131547a4-7f1b-484b-8930-becfdca7459f">
<img width="581" alt="Screen Shot 2024-01-16 at 8 39 34 AM" src="https://github.com/parameter1/randall-reilly-newsletters/assets/64623209/5f04e25a-faf1-4598-bd57-91addf2be6da">
<img width="527" alt="Screen Shot 2024-01-16 at 8 41 03 AM" src="https://github.com/parameter1/randall-reilly-newsletters/assets/64623209/21ad440b-6bc2-49c0-8ab5-47fd1e38afc0">
