### PR TITLE
Ability to rename primary section withing list item

### DIFF
--- a/packages/common/components/blocks/content/list-item.marko
+++ b/packages/common/components/blocks/content/list-item.marko
@@ -52,7 +52,14 @@ $ const sponsoredTagStyle = {
       </if>
       <else-if(withSection)>
         <tr>
-          <td align="left" valign="top" style=tagStyle>${get(content, "primarySection.name")}</td>
+          <td align="left" valign="top" style=tagStyle>
+            $ const name = get(content, "primarySection.name");
+            $ const secNameToName = {
+              "White Papers": 'Partner Insights',
+            };
+            $ const label = secNameToName[name] ? secNameToName[name] : name;
+            ${label}
+          </td>
         </tr>
       </else-if>
 


### PR DESCRIPTION
They currently brand their white papers section on all home pages as Partner Insights

This will allow for a similar functionality with the context of the newsletters.  If need be this can be more complicated and pulled into individual newsletter configs, but for now we will keep it simple.  :) 

https://trello.com/c/hVMhkkGl/318-rename-whitepapers-promo-card-to-partner-insights

![Screenshot 2024-01-17 at 4 08 35 PM](https://github.com/parameter1/randall-reilly-newsletters/assets/3845869/58c9f003-fd79-4867-a8df-457ecb5058db)
