### PR TITLE
Allow '&' on Native-X ad's

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -49,8 +49,7 @@ services:
     <<: *newsletter-cmd
     working_dir: /root/tenants/all
     environment:
-      <<: *env
-      <<: *env-virgon
+      <<: [*env, *env-virgon]
       PORT: 80
       EXPOSED_PORT: 22290
       LIVERELOAD_PORT: 32290

--- a/packages/common/components/blocks/ad/promotion-advertisement.marko
+++ b/packages/common/components/blocks/ad/promotion-advertisement.marko
@@ -56,7 +56,7 @@ $ const imgLinkStyles = {
                       </tr>
                       <common-table-spacer-element height="12" />
                       <tr>
-                        <td align="left" valign="top" style="font-size: 17px;line-height: 22px;color: #202022;padding:0 24px 0 0;">${content.teaser}</td>
+                        <td align="left" valign="top" style="font-size: 17px;line-height: 22px;color: #202022;padding:0 24px 0 0;">$!{content.teaser}</td>
                       </tr>
                       <tr>
                         <td align="left" valign="top">
@@ -160,7 +160,7 @@ $ const imgLinkStyles = {
                       </tr>
                       <common-table-spacer-element height="12" />
                       <tr>
-                        <td align="left" valign="top" style="font-size: 17px;line-height: 22px;color: #202022;padding:0 24px 0 0;">${content.teaser}</td>
+                        <td align="left" valign="top" style="font-size: 17px;line-height: 22px;color: #202022;padding:0 24px 0 0;">$!{content.teaser}</td>
                       </tr>
                       <common-table-spacer-element height="9" />
                       <tr>
@@ -241,7 +241,7 @@ $ const imgLinkStyles = {
                       </tr>
                       <common-table-spacer-element height="12" />
                       <tr>
-                        <td align="left" valign="top" style="font-size: 17px;line-height: 22px;color: #202022;padding:0 24px 0 0;">${content.teaser}</td>
+                        <td align="left" valign="top" style="font-size: 17px;line-height: 22px;color: #202022;padding:0 24px 0 0;">$!{content.teaser}</td>
                       </tr>
                       <common-table-spacer-element height="9" />
                       <tr>

--- a/packages/common/components/blocks/ad/promotion-sponsored.marko
+++ b/packages/common/components/blocks/ad/promotion-sponsored.marko
@@ -57,7 +57,7 @@ $ const imgLinkStyles = {
                                         <td align="left" valign="top" style="font-size:16px;line-height:19px;color:#202022;font-weight:700;">${company.name}</td>
                                       </tr>
                                       <tr>
-                                        <td align="left" valign="top" style="font-size:16px;line-height:22px;color:#202022;font-weight:400;">${content.teaser}</td>
+                                        <td align="left" valign="top" style="font-size:16px;line-height:22px;color:#202022;font-weight:400;">$!{content.teaser}</td>
                                       </tr>
                                     </table>
                                   </td>


### PR DESCRIPTION
<img width="915" alt="Screenshot 2024-07-01 at 3 25 18 PM" src="https://github.com/parameter1/randall-reilly-newsletters/assets/64623209/c1ebbf80-cc2e-46a0-9d6f-572e506b8d85">
